### PR TITLE
Update azuredevops_provider.py

### DIFF
--- a/pr_agent/git_providers/azuredevops_provider.py
+++ b/pr_agent/git_providers/azuredevops_provider.py
@@ -383,7 +383,7 @@ class AzureDevopsProvider(GitProvider):
             get_logger().debug(f"Skipping publish_comment for temporary comment: {pr_comment}")
             return None
         comment = Comment(content=pr_comment)
-        thread = CommentThread(comments=[comment], thread_context=thread_context, status=5)
+        thread = CommentThread(comments=[comment], thread_context=thread_context, status=1)
         thread_response = self.azure_devops_client.create_thread(
             comment_thread=thread,
             project=self.workspace_slug,


### PR DESCRIPTION
Will make qodo agent comments "Active" by default, and not "ByDesign" which is renders to "unknown" on Azure DevOps PRs. With this, PR authors are obliged to treat the PR comment of the qodo agent before Merging. This will help companies in analysing the impact of qodo agent on their PR, as every comment needs to be treated as either "Resolved" "Won't fix" "Close"